### PR TITLE
let cheerio do not decode entities

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -18,7 +18,7 @@ exports.heading = function (data) {
 
     var options = assign({}, this.config.toc);
 
-    var $ = cheerio.load(data.content);
+    var $ = cheerio.load(data.content, {decodeEntities: false});
     var headings = $('h1, h2, h3, h4, h5, h6');
 
     headings.each(function () {


### PR DESCRIPTION
**Critical**
this fix that non-latin characters (like Chinese) get HTML-encoded problem.

cf.:
1. https://github.com/hexojs/hexo/issues/657
2. https://github.com/cheeriojs/cheerio/issues/565
3. https://github.com/cheeriojs/cheerio/issues/866
4. http://cnodejs.org/topic/54bdd639514ea9146862ac37

