### PR TITLE
Choose entity decoding settings and Optimized h2 to h6 tag for Google Jump-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ toc:
   maxdepth: 3
   class: toc
   slugify: transliteration
+  decodeEntities: false
   anchor:
     position: after
     symbol: '#'
@@ -39,6 +40,7 @@ toc:
 - `maxdepth`: Use headings whose depth is at most maxdepth.
 - `class`: The CSS Class for the toc. (*Default is `false`*)
 - `slugify`: Choose which slugify function you want to use. Currently support [uslug](https://github.com/jeremys/uslug) (*Default*) and [transliteration](https://github.com/andyhu/node-transliteration).
+- `decodeEntities`: Select whether to enable decode entities. ( *Default is `false`* and please see [#15](https://github.com/bubkoo/hexo-toc/pull/15)).
 - `anchor`: Whether should have an anchor for each headings. (*Default is `false`*)
     - `position`: Where should the anchor be, `before` the title, or `after` the title. (*Default is `after`*);
     - `symbol`: Which symbol you want the anchor be. (*Default is `#`*);

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -18,14 +18,18 @@ exports.insert = function (data) {
 exports.heading = function (data) {
   var options = assign({}, this.config.toc);
 
-  var $ = cheerio.load(data.content, { decodeEntities: false });
+  var $ = cheerio.load(data.content, { decodeEntities: ( options.decodeEntities !== undefined ? options.decodeEntities : false ) });
   var headings = $('h1, h2, h3, h4, h5, h6');
 
   headings.each(function () {
     var $title = $(this);
     var title = $title.text();
     var id = toc.slugify(title, options);
-    $title.attr('id', id);
+    // $title.attr('id', id);
+    $title.children('a').remove();
+    $title.html( '<span id="' + id + '">' + $title.html() + '</span>' );
+    $title.removeAttr('id');
+
 
     if (options.anchor) {
       var anchorOpts = assign(


### PR DESCRIPTION
## Description

1. `decodeEntities:false` does not work well in Japanese. So I want to freely change `decodeEntities` settings about [#15](https://github.com/bubkoo/hexo-toc/pull/15/files#diff-77a92250315fdf44b4ecf5b3fcf5fd3cR21).

2. Optimized h2 to h6 tag for Google [Jump-links](https://jrotman.wordpress.com/2009/09/28/googles-new-jump-to-links-seo-copy-content/)

## Update

- Added `decodeEntities` option ( default : `false`).
- Edited README.md about `decodeEntities` option.
- Optimized h2 to h6 tag for Google [Jump-links](https://jrotman.wordpress.com/2009/09/28/googles-new-jump-to-links-seo-copy-content/)